### PR TITLE
Inform systemd about the state of the service

### DIFF
--- a/kaoz/bot.py
+++ b/kaoz/bot.py
@@ -65,6 +65,9 @@ def main(argv):
     parser.add_option(
         '-l', '--logstd', action='store_true', dest='logstd', default=False,
         help="log messages to standard channel")
+    parser.add_option(
+        '--notify-systemd', action='store_true', dest='notify_systemd', default=False,
+        help="notify systemd service manager about the status of the service")
 
     opts, argv = parser.parse_args(argv)
 
@@ -96,7 +99,8 @@ def main(argv):
     # Start publisher and listener as daemon threads
     event = threading.Event()
     publisher = publishbot.PublisherThread(config, event=event,
-                                           debug=opts.debug)
+                                           debug=opts.debug,
+                                           notify_systemd=opts.notify_systemd)
     publisher.daemon = True
     tcplistener = listener.TCPListener(publisher, config, event=event)
     tcplistener.daemon = True

--- a/systemd/kaoz.service
+++ b/systemd/kaoz.service
@@ -3,7 +3,9 @@ Description=Kaoz IRC notifier bot
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/kaoz
+Type=notify
+NotifyAccess=main
+ExecStart=/usr/bin/kaoz --notify-systemd --logstd
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hello,
When installing kaoz on Debian Jessie running with systemd, the daemon may stop when an IRC error occurs (e.g. the server went down, the nickname was already in use, etc.). In such situations, systemd reports the daemon as still running, which prevents it from triggering an "auto-respawn" procedure.

Introduce a new option, `--notify-systemd`, to notify systemd about the status of the service in its lifetime and use it in the provided kaoz.service file. Moreover make "systemctl start kaoz" wait for an IRC connection to be established (more precisely until a welcome message has been received) and make it fail if the service fails to start.

Could you please review and merge this PR?
Cheers!